### PR TITLE
refactor: :recycle: establish `Database` interface to allow testability

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -1,10 +1,12 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/jonnaylang101/sql-iterator/iterator"
 )
 
 type DbConfig struct {
@@ -16,11 +18,53 @@ func (cfg DbConfig) CreateConnectionString() string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.DbName)
 }
 
-func New(dbConfig DbConfig) (*sql.DB, error) {
-	db, err := sql.Open("mysql", dbConfig.CreateConnectionString())
+type Database[T any] interface {
+	Query(context.Context, string) (<-chan T, error)
+}
+
+type database[T any] struct {
+	sql          *sql.DB
+	bufferSize   int
+	customBinder iterator.CustomBinder[T]
+}
+
+func NewDB[T any](cfg DbConfig, binder iterator.CustomBinder[T], bufferSize int) (Database[T], error) {
+	sql, err := sql.Open("mysql", cfg.CreateConnectionString())
 	if err != nil {
-		return db, fmt.Errorf("database.New: error occurred whild initializing the database: %v", err)
+		return &database[T]{}, fmt.Errorf("database.New: error occurred whild initializing the database: %v", err)
 	}
 
-	return db, nil
+	return &database[T]{
+		sql:          sql,
+		bufferSize:   bufferSize,
+		customBinder: binder,
+	}, nil
+}
+
+func (db *database[T]) Query(ctx context.Context, qString string) (<-chan T, error) {
+	rows, err := db.sql.Query(qString)
+	if err != nil {
+		return nil, err
+	}
+
+	return genDataChansFromRows(ctx, rows, db.bufferSize, db.customBinder), nil
+}
+
+// this is a copy for now until this idea is tested
+func genDataChansFromRows[R any](ctx context.Context, rows *sql.Rows, bufferSize int, binder iterator.CustomBinder[R]) <-chan R {
+	outStream := make(chan R, bufferSize)
+
+	go func() {
+		defer close(outStream)
+
+		select {
+		case <-ctx.Done():
+		default:
+			for rows.Next() {
+				outStream <- binder(rows)
+			}
+		}
+	}()
+
+	return outStream
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	db    *sql.DB
+	db    database.Database[DbResult]
 	table string
 )
 
@@ -67,7 +67,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	db, err = database.New(cfg)
+	db, err = database.NewDB(cfg, DbResultBinder, 20)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
we can encapsulate the sql db query behaviour to give us a mockable method on our Database interface